### PR TITLE
Separated Endpoint related objects from bigger PR

### DIFF
--- a/src/main/java/com/teragrep/nbs_01/endpoints/directory/CopyDirectoryEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/directory/CopyDirectoryEndpoint.java
@@ -1,0 +1,128 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.directory;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import jakarta.json.Json;
+import jakarta.json.JsonException;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that copies a Directory based on a given Identifier, and creates a new Directory containing copies of the original Directory's children to a new location based on another Identifier.
+public final class CopyDirectoryEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public CopyDirectoryEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier sourceIdentifier = request.sourceIdentifier();
+            final Identifier targetIdentifier = request.targetIdentifier();
+            root.copyDirectory(sourceIdentifier, targetIdentifier);
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(
+                    HttpStatus.CREATED_201,
+                    new JSONBody(Json.createObjectBuilder().build()),
+                    headers
+            );
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final FileAlreadyExistsException | MalformedRequestException | JsonException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CopyDirectoryEndpoint that = (CopyDirectoryEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/directory/CreateDirectoryEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/directory/CreateDirectoryEndpoint.java
@@ -1,0 +1,122 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.directory;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import jakarta.json.Json;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that creates a new Directory to a location based on an Identifier.
+public final class CreateDirectoryEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public CreateDirectoryEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            root.writeDirectory(targetIdentifier);
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(
+                    HttpStatus.CREATED_201,
+                    new JSONBody(Json.createObjectBuilder().build()),
+                    headers
+            );
+        }
+        catch (final MalformedRequestException | FileAlreadyExistsException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CreateDirectoryEndpoint that = (CreateDirectoryEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/directory/DeleteDirectoryEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/directory/DeleteDirectoryEndpoint.java
@@ -1,0 +1,126 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.directory;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import jakarta.json.Json;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that deletes a Directory from a location based on an Identifier.
+public final class DeleteDirectoryEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public DeleteDirectoryEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            root.deleteDirectory(targetIdentifier);
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            response = new BasicHTTPResponse(
+                    HttpStatus.NO_CONTENT_204,
+                    new JSONBody(Json.createObjectBuilder().build()),
+                    headers
+            );
+        }
+        catch (final MalformedRequestException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        // DELETE requests should return 404 NOT FOUND if the requested file doesn't exist in the first place
+        catch (final NoSuchFileException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        // Any other IOException indicates that a more critical error happened, and should be logged.
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DeleteDirectoryEndpoint that = (DeleteDirectoryEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/directory/FindDirectoryEndPoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/directory/FindDirectoryEndPoint.java
@@ -1,0 +1,121 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.directory;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Finds a given Directory and returns its own name and the names of its children in JSON format based on a given Identifier.
+public final class FindDirectoryEndPoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public FindDirectoryEndPoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            // Find a directory and get a list of its children
+            final Identifier targetIdentifier = request.targetIdentifier();
+            final String directoryContent = root.readDirectory(targetIdentifier);
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(HttpStatus.OK_200, new StringBody(directoryContent), headers);
+        }
+        catch (final MalformedRequestException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final FindDirectoryEndPoint that = (FindDirectoryEndPoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/general/Delegate.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/general/Delegate.java
@@ -1,0 +1,54 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.general;
+
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+
+// Interface for a Delegate, that inspects a Request object, and returns either a true or a false value according to implementation details.
+public abstract interface Delegate {
+
+    public abstract boolean resolve(HTTPRequest request);
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/general/DelegatingEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/general/DelegatingEndpoint.java
@@ -1,0 +1,79 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.general;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+
+// Endpoint that delegates the request to one of a collection of Endpoints based on the result of a Delegate
+public class DelegatingEndpoint implements HTTPEndPoint {
+
+    private final Delegate delegate;
+    private final HTTPEndPoint trueEndPoint;
+    private final HTTPEndPoint falseEndPoint;
+
+    public DelegatingEndpoint(
+            final HTTPEndPoint trueEndPoint,
+            final HTTPEndPoint falseEndPoint,
+            final Delegate delegate
+    ) {
+        this.trueEndPoint = trueEndPoint;
+        this.falseEndPoint = falseEndPoint;
+        this.delegate = delegate;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        final HTTPResponse response;
+        if (delegate.resolve(request)) {
+            response = trueEndPoint.createResponse(request);
+        }
+        else {
+            response = falseEndPoint.createResponse(request);
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/general/DoAllKeysExistDelegate.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/general/DoAllKeysExistDelegate.java
@@ -1,0 +1,100 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.general;
+
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+// Delegate that checks if a key is present in a Request, and returns either true or false based on the keys existence.
+public final class DoAllKeysExistDelegate implements Delegate {
+
+    private final List<String> keys;
+
+    public DoAllKeysExistDelegate(final String key) {
+        this.keys = Arrays.asList(key);
+    }
+
+    public DoAllKeysExistDelegate(final List<String> keys) {
+        this.keys = keys;
+    }
+
+    public boolean resolve(final HTTPRequest request) {
+        if (request.body().isStub()) {
+            return false;
+        }
+        final JsonObject parameters;
+        parameters = Json.createReader(new StringReader(request.body().asString())).readObject();
+        for (final String key : keys) {
+            if (!parameters.containsKey(key)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DoAllKeysExistDelegate delegate = (DoAllKeysExistDelegate) o;
+        return Objects.equals(keys, delegate.keys);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keys);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/general/ListEndPoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/general/ListEndPoint.java
@@ -1,0 +1,118 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.general;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.identifiers.PathIdentifier;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+// Endpoint that lists all the paths of saved notebooks in a given Directory.
+public final class ListEndPoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public ListEndPoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        // Find all notebooks from Directory structure
+        try {
+            final List<Identifier> currentFiles = root.listFiles(new PathIdentifier(""));
+            final JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+            for (final Identifier file : currentFiles) {
+                arrayBuilder.add(file.asShortString());
+            }
+            final JsonArray array = arrayBuilder.build();
+            response = new BasicHTTPResponse(HttpStatus.OK_200, new JSONBody(array));
+        }
+        catch (final MalformedRequestException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ListEndPoint that = (ListEndPoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/general/PingEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/general/PingEndpoint.java
@@ -1,0 +1,69 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.general;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import org.eclipse.jetty.http.HttpStatus;
+
+// Endpoint that returns a "pong" response to any request. Can be used as a heartbeat function.
+public final class PingEndpoint implements HTTPEndPoint {
+
+    public PingEndpoint() {
+
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        return new BasicHTTPResponse(
+                HttpStatus.OK_200,
+                new JSONBody(Json.createObjectBuilder().add("message", "pong").build())
+        );
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/general/StubEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/general/StubEndpoint.java
@@ -1,0 +1,70 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.general;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import org.eclipse.jetty.http.HttpStatus;
+
+// Stub object for Endpoints.
+public final class StubEndpoint implements HTTPEndPoint {
+
+    // On receiving a request, returns a 405 METHOD NOT ALLOWED
+    public StubEndpoint() {
+
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        return new BasicHTTPResponse(
+                HttpStatus.METHOD_NOT_ALLOWED_405,
+                new JSONBody(Json.createObjectBuilder().build())
+        );
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/notebook/CopyNotebookEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/notebook/CopyNotebookEndpoint.java
@@ -1,0 +1,137 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.serialization.SerializedNotebook;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import jakarta.json.JsonException;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that copies a Notebook based on a given Identifier, and creates a new Notebook with the same content to a location based on another Identifier.
+public final class CopyNotebookEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public CopyNotebookEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier sourceIdentifier = request.sourceIdentifier();
+            final Identifier targetIdentifier = request.targetIdentifier();
+
+            // Deserialize source from Storage
+            final Notebook source = root.deserializeNotebook(sourceIdentifier);
+
+            // Create a copy, which also generates unique IDs for copied paragraphs.
+            final Notebook copy = source.copy();
+            // Serialize copy to storage
+            final SerializedNotebook serializedDestination = root.serializeNotebook(copy);
+            root.writeFile(targetIdentifier, serializedDestination.serialize());
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(
+                    HttpStatus.CREATED_201,
+                    new StringBody(serializedDestination.serialize()),
+                    headers
+            );
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final MalformedRequestException | JsonException | FileAlreadyExistsException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CopyNotebookEndpoint that = (CopyNotebookEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/notebook/CreateNotebookEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/notebook/CreateNotebookEndpoint.java
@@ -1,0 +1,135 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import com.teragrep.nbs_01.repository.serialization.SerializedNotebook;
+import jakarta.json.JsonException;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that Creates a new Notebook to a location based on a given Identifier.
+public final class CreateNotebookEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public CreateNotebookEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            String title;
+            try {
+                title = request.title();
+            }
+            catch (MalformedRequestException e) {
+                title = "";
+            }
+
+            // Create new notebook and serialize it to Storage
+            final Notebook newFile = new Notebook(title);
+            final SerializedNotebook notebook = root.serializeNotebook(newFile);
+            root.writeFile(targetIdentifier, notebook.serialize());
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(HttpStatus.CREATED_201, new StringBody(notebook.serialize()), headers);
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final FileAlreadyExistsException | MalformedRequestException | JsonException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CreateNotebookEndpoint that = (CreateNotebookEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/notebook/DeleteNotebookEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/notebook/DeleteNotebookEndpoint.java
@@ -1,0 +1,124 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that deletes a Notebook from a location based on a given Identifier.
+public final class DeleteNotebookEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public DeleteNotebookEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            root.deleteFile(targetIdentifier);
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            response = new BasicHTTPResponse(HttpStatus.NO_CONTENT_204, headers);
+        }
+        catch (final MalformedRequestException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        // DELETE requests should return 404 NOT FOUND if the requested file doesn't exist in the first place
+        catch (final NoSuchFileException notFoundException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.NOT_FOUND_404,
+                    new ExceptionBody(new FileNotFoundException("No such file!"))
+            );
+        }
+        // Any other IOException indicates that a more critical error happened, and should be logged.
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DeleteNotebookEndpoint that = (DeleteNotebookEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/notebook/FindNotebookEndPoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/notebook/FindNotebookEndPoint.java
@@ -1,0 +1,136 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import com.teragrep.nbs_01.repository.serialization.SerializedNotebook;
+import jakarta.json.JsonException;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that finds a Notebook with a given Identifier and returns its contents in JSON format.
+public final class FindNotebookEndPoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public FindNotebookEndPoint(final Storage root) {
+        this.root = root;
+    }
+
+    @Override
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+
+            // Deserialize from Storage
+
+            // We cannot simply return the file contents as is back to the UI using root.read(), since it's possible that there are legacy Zeppelin files, which have a different structure.
+            // Therefore, we must first create an in-memory Notebook object first via root.deserialize(), which will format the notebook properly whether it was sourced from a legacy file or not.
+            final Notebook notebook = root.deserializeNotebook(targetIdentifier);
+            final SerializedNotebook serializedNotebook = root.serializeNotebook(notebook);
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(
+                    HttpStatus.OK_200,
+                    new StringBody(serializedNotebook.serialize()),
+                    headers
+            );
+        }
+        catch (final MalformedRequestException malformedRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(malformedRequestException));
+        }
+        // If the file cannot be found from Storage, respond with a 404 not found.
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        // If Storage throws an IOException while accessing file contents, or the file contents retrieved from storage are not valid JSON, respond with a 500 internal server error.
+        catch (final IOException | JsonException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final FindNotebookEndPoint that = (FindNotebookEndPoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/notebook/UpdateNotebookEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/notebook/UpdateNotebookEndpoint.java
@@ -1,0 +1,131 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.serialization.SerializedNotebook;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import jakarta.json.JsonException;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that updates the title of a Notebook based on a given Identifier
+public final class UpdateNotebookEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public UpdateNotebookEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            final String title = request.title();
+
+            // Deserialize current notebook from Storage
+            final Notebook serializedNotebook = root.deserializeNotebook(targetIdentifier);
+
+            // Create a new Notebook with the modified title and serialize it to Storage.
+            final Notebook modifiedNotebook = new Notebook(title, serializedNotebook.paragraphs());
+            final SerializedNotebook serializedModifiedNotebook = root.serializeNotebook(modifiedNotebook);
+            root.writeFile(targetIdentifier, serializedModifiedNotebook.serialize());
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(HttpStatus.OK_200, new StringBody(modifiedNotebook.title()), headers);
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final MalformedRequestException | JsonException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final UpdateNotebookEndpoint that = (UpdateNotebookEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/CopyParagraphEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/CopyParagraphEndpoint.java
@@ -1,0 +1,156 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.repository.Paragraph;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.serialization.SerializedNotebook;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import jakarta.json.JsonException;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+
+// Endpoint that finds a Paragraph with a given Id from a Notebook based on an Identifier and then creates a new paragraph to another existing Notebook identified with another Identifier, using a given paragraphID.
+public final class CopyParagraphEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public CopyParagraphEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final String sourceParagraphId = request.sourceParagraphId();
+            final String targetParagraphId = request.targetParagraphId();
+            final Identifier sourceIdentifier = request.sourceIdentifier();
+            final Identifier targetIdentifier = request.targetIdentifier();
+
+            // Deserialize source notebook from Storage
+            final Notebook serializedSource = root.deserializeNotebook(sourceIdentifier);
+            final Map<String, Paragraph> sourceParagraphs = serializedSource.paragraphs();
+
+            // Throw error if requested source paragraph doesn't exist
+            if (!sourceParagraphs.containsKey(sourceParagraphId)) {
+                throw new FileNotFoundException("No such paragraph: " + sourceParagraphId + "!");
+            }
+
+            // Create a copy of the paragraph from the source notebook
+            final Paragraph sourceParagraph = sourceParagraphs.get(sourceParagraphId);
+            final Paragraph copyParagraph = sourceParagraph.copy(targetParagraphId);
+
+            // Deserialize destination notebook from Storage, and add the copied paragraph
+            final Notebook serializedDestination = root.deserializeNotebook(targetIdentifier);
+            final Map<String, Paragraph> destinationParagraphs = serializedDestination.paragraphs();
+            // Throw error if requested destination paragraph already exists in destination notebook
+            if (destinationParagraphs.containsKey(copyParagraph.id())) {
+                throw new MalformedRequestException("Paragraph " + copyParagraph.id() + " already exists!");
+            }
+            destinationParagraphs.put(copyParagraph.id(), copyParagraph);
+
+            // Serialize edited destination notebook to storage
+            final Notebook destinationNotebook = new Notebook(serializedDestination.title(), destinationParagraphs);
+            final SerializedNotebook serializedDestinationNotebook = root.serializeNotebook(destinationNotebook);
+            root.writeFile(targetIdentifier, serializedDestinationNotebook.serialize());
+
+            // Create response
+            final String paragraphContent = root.serializeParagraph(copyParagraph).serialize();
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(HttpStatus.CREATED_201, new StringBody(paragraphContent), headers);
+        }
+        catch (final FileAlreadyExistsException | MalformedRequestException | JsonException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CopyParagraphEndpoint that = (CopyParagraphEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/CreateParagraphEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/CreateParagraphEndpoint.java
@@ -1,0 +1,139 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.repository.Paragraph;
+import com.teragrep.nbs_01.repository.Script;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.serialization.SerializedNotebook;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that creates a new Paragraph with a given ID into a given Notebook based on an Identifier.
+public final class CreateParagraphEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public CreateParagraphEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            final String targetParagraphId = request.targetParagraphId();
+
+            // Deserialize notebook
+            final Notebook notebook = root.deserializeNotebook(targetIdentifier);
+
+            // Throw error if a paragraph with the ID already exists.
+            if (notebook.paragraphs().containsKey(targetParagraphId)) {
+                throw new MalformedRequestException("Paragraph " + targetParagraphId + " already exists!");
+            }
+
+            // Add a new empty paragraph to the notebook and serialize to Storage
+            final Paragraph newParagraph = new Paragraph(targetParagraphId, "", new Script(""));
+            notebook.paragraphs().put(targetParagraphId, newParagraph);
+            final SerializedNotebook serializedNotebook = root.serializeNotebook(notebook);
+            root.writeFile(targetIdentifier, serializedNotebook.serialize());
+
+            // Create response
+            final String paragraphContent = root.serializeParagraph(newParagraph).serialize();
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(HttpStatus.CREATED_201, new StringBody(paragraphContent), headers);
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        catch (final MalformedRequestException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CreateParagraphEndpoint that = (CreateParagraphEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/DeleteParagraphEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/DeleteParagraphEndpoint.java
@@ -1,0 +1,133 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import com.teragrep.nbs_01.repository.serialization.SerializedNotebook;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that deletes a Paragraph with a given id from a Notebook based on an Identifier.
+public final class DeleteParagraphEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public DeleteParagraphEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            final String targetParagraphId = request.targetParagraphId();
+
+            // Deserialize notebook from Storage
+            final Notebook notebook = root.deserializeNotebook(targetIdentifier);
+
+            // Throw error if paragraph with given ID does not exist
+            if (!notebook.paragraphs().containsKey(targetParagraphId)) {
+                throw new MalformedRequestException("Paragraph " + targetParagraphId + " doesn't exist!");
+            }
+
+            // Remove the paragraph and serialize notebook to Storage
+            notebook.paragraphs().remove(targetParagraphId);
+            final SerializedNotebook serializedNotebook = root.serializeNotebook(notebook);
+            root.writeFile(targetIdentifier, serializedNotebook.serialize());
+
+            // Create response
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            response = new BasicHTTPResponse(HttpStatus.NO_CONTENT_204, headers);
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        catch (final MalformedRequestException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DeleteParagraphEndpoint that = (DeleteParagraphEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/FindParagraphEndPoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/FindParagraphEndPoint.java
@@ -1,0 +1,129 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+// Endpoint that searches for a paragraph with a given ID from a Notebook based on an Identifier, and returns its contents in JSON format.
+public final class FindParagraphEndPoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public FindParagraphEndPoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            final String paragraphId = request.targetParagraphId();
+
+            // Deserialize from Storage
+            final Notebook notebook = root.deserializeNotebook(targetIdentifier);
+
+            if (!notebook.paragraphs().containsKey(paragraphId)) {
+                throw new MalformedRequestException("Paragraph with id " + paragraphId + " not found!");
+            }
+
+            // Create response
+            final String paragraphContent = root.serializeParagraph(notebook.paragraphs().get(paragraphId)).serialize();
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(HttpStatus.OK_200, new StringBody(paragraphContent), headers);
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        catch (final MalformedRequestException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final FindParagraphEndPoint that = (FindParagraphEndPoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/UpdateParagraphEndpoint.java
+++ b/src/main/java/com/teragrep/nbs_01/endpoints/paragraph/UpdateParagraphEndpoint.java
@@ -1,0 +1,162 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.protocols.http.HTTPEndPoint;
+import com.teragrep.nbs_01.exceptions.MalformedRequestException;
+import com.teragrep.nbs_01.protocols.http.body.ErrorBody;
+import com.teragrep.nbs_01.exceptions.ErrorEvent;
+import com.teragrep.nbs_01.protocols.http.body.ExceptionBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPResponse;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import com.teragrep.nbs_01.repository.Notebook;
+import com.teragrep.nbs_01.repository.Paragraph;
+import com.teragrep.nbs_01.repository.Script;
+import com.teragrep.nbs_01.repository.identifiers.Identifier;
+import com.teragrep.nbs_01.repository.serialization.SerializedNotebook;
+import com.teragrep.nbs_01.repository.storage.Storage;
+import jakarta.json.JsonException;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+
+// Endpoint that updates the text and/or title of a paragraph with a given ID within a Notebook based on an Identifier.
+public final class UpdateParagraphEndpoint implements HTTPEndPoint {
+
+    private final Storage root;
+
+    public UpdateParagraphEndpoint(final Storage root) {
+        this.root = root;
+    }
+
+    public HTTPResponse createResponse(final HTTPRequest request) {
+        HTTPResponse response;
+        try {
+            final Identifier targetIdentifier = request.targetIdentifier();
+            final String paragraphId = request.targetParagraphId();
+
+            // Deserialize notebook from Storage
+            final Notebook notebook = root.deserializeNotebook(targetIdentifier);
+            final Map<String, Paragraph> paragraphs = notebook.paragraphs();
+
+            // Throw an error if the paragraph doesn't exist
+            if (!paragraphs.containsKey(paragraphId)) {
+                throw new MalformedRequestException("Paragraph with Id " + paragraphId + " not found!");
+            }
+            final Paragraph originalParagraph = paragraphs.get(paragraphId);
+
+            // Get modified script text and / or title from request.
+            String scriptText;
+            try {
+                scriptText = request.text();
+            }
+            catch (final MalformedRequestException exception) {
+                scriptText = originalParagraph.script().text();
+            }
+            // Retrieve the title from the request. If the request does not have a title, use the existing title of the paragraph.
+            String title;
+            try {
+                title = request.title();
+            }
+            catch (final MalformedRequestException exception) {
+                title = originalParagraph.title();
+            }
+            final Script newScript = new Script(scriptText);
+
+            // Overwrite the old paragraph with the edited paragraph, and serialize the notebook to Storage
+            final Paragraph newParagraph = new Paragraph(originalParagraph.id(), title, newScript);
+            paragraphs.put(newParagraph.id(), newParagraph);
+            final Notebook newNotebook = new Notebook(notebook.title(), paragraphs);
+            final SerializedNotebook serializedNotebook = root.serializeNotebook(newNotebook);
+            root.writeFile(targetIdentifier, serializedNotebook.serialize());
+
+            // Create response
+            final String paragraphContent = root.serializeParagraph(newParagraph).serialize();
+            final ArrayList<Header> headers = new ArrayList<>();
+            headers.add(new BasicHeader("Location", targetIdentifier.asLongString()));
+            headers.add(new BasicHeader("Content-Type", "application/json"));
+            response = new BasicHTTPResponse(HttpStatus.OK_200, new StringBody(paragraphContent), headers);
+        }
+        catch (final MalformedRequestException | JsonException badRequestException) {
+            response = new BasicHTTPResponse(HttpStatus.BAD_REQUEST_400, new ExceptionBody(badRequestException));
+        }
+        catch (final FileNotFoundException notFoundException) {
+            response = new BasicHTTPResponse(HttpStatus.NOT_FOUND_404, new ExceptionBody(notFoundException));
+        }
+        catch (final IOException serverErrorException) {
+            response = new BasicHTTPResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR_500,
+                    new ErrorBody(new ErrorEvent(serverErrorException))
+            );
+        }
+        return response;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final UpdateParagraphEndpoint that = (UpdateParagraphEndpoint) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/DoAllKeysExistDelegateTest.java
+++ b/src/test/java/com/teragrep/nbs_01/DoAllKeysExistDelegateTest.java
@@ -1,0 +1,121 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01;
+
+import com.teragrep.nbs_01.endpoints.general.DoAllKeysExistDelegate;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPRequest;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class DoAllKeysExistDelegateTest {
+
+    private final String testKey1 = "testKey1";
+
+    private final String testKey2 = "testKey2";
+    private final String testKey3 = "testKey3";
+
+    @Test
+    public void resolvePresentKeys() {
+        Assertions.assertDoesNotThrow(() -> {
+            final List<String> testKeys = new ArrayList<>();
+            testKeys.add(testKey1);
+            testKeys.add(testKey2);
+            testKeys.add(testKey3);
+            final DoAllKeysExistDelegate delegate = new DoAllKeysExistDelegate(testKeys);
+
+            final JsonObject body = Json
+                    .createObjectBuilder()
+                    .add(testKey1, "testValue1")
+                    .add(testKey2, "testValue2")
+                    .add(testKey3, "testValue3")
+                    .build();
+            final HTTPRequest testRequest = new BasicHTTPRequest(new JSONBody(body));
+            Assertions.assertTrue(delegate.resolve(testRequest));
+        });
+    }
+
+    @Test
+    public void resolveMissingKey() {
+        Assertions.assertDoesNotThrow(() -> {
+            final List<String> testKeys = new ArrayList<>();
+            testKeys.add(testKey1);
+            testKeys.add(testKey2);
+            testKeys.add(testKey3);
+            final DoAllKeysExistDelegate delegate = new DoAllKeysExistDelegate(testKeys);
+            final JsonObject body = Json
+                    .createObjectBuilder()
+                    .add(testKey1, "testValue1")
+                    .add(testKey2, "testValue2")
+                    .build();
+            final HTTPRequest testRequest = new BasicHTTPRequest(new JSONBody(body));
+            Assertions.assertFalse(delegate.resolve(testRequest));
+        });
+    }
+
+    @Test
+    public void resolveEmptyKeys() {
+        Assertions.assertDoesNotThrow(() -> {
+            final List<String> testKeys = new ArrayList<>();
+            final DoAllKeysExistDelegate delegate = new DoAllKeysExistDelegate(testKeys);
+            final JsonObject body = Json.createObjectBuilder().add(testKey1, "testValue1").build();
+            final HTTPRequest testRequest = new BasicHTTPRequest(new JSONBody(body));
+            Assertions.assertTrue(delegate.resolve(testRequest));
+        });
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(DoAllKeysExistDelegate.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/ListEndPointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/ListEndPointTest.java
@@ -1,0 +1,94 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.endpoints.general.ListEndPoint;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ListEndPointTest extends AbstractNotebookServerTest {
+
+    private final List<String> allFileIds = Arrays
+            .asList("2A94M5J1Z", "2A94M5J2Z", "2A94M5J3Z", "2A94M5J4Z", "junkfile");
+    private final List<String> allFileIdsWithinDirectory = Arrays.asList("2A94M5J1Z", "2A94M5J2Z");
+
+    @Test
+    // Assert that a HTTP request to /notebook/list endpoint results in a list of notebook IDs
+    public void httpListAllTest() {
+        final ListEndPoint listEndPoint = new ListEndPoint(new LocalFilesystemStorage(notebookDirectory()));
+        final HTTPResponse response = listEndPoint.createResponse(new BasicHTTPRequest());
+        for (final String filename : allFileIds) {
+            Assertions.assertDoesNotThrow(() -> Assertions.assertTrue(response.body().asString().contains(filename)));
+        }
+    }
+
+    @Test
+    // Assert that a HTTP request with a defined DirectoryId to /notebook/list endpoint results in a list of notebook IDs contained in that directory
+    public void httpListWithinFolderTest() {
+        final ListEndPoint listEndPoint = new ListEndPoint(new LocalFilesystemStorage(notebookDirectory()));
+        final JsonObject requestBody = Json.createObjectBuilder().add("directoryPath", directory1().toString()).build();
+        final HTTPResponse response = listEndPoint.createResponse(new BasicHTTPRequest(new JSONBody(requestBody)));
+        for (final String filename : allFileIdsWithinDirectory) {
+            Assertions.assertDoesNotThrow(() -> Assertions.assertTrue(response.body().asString().contains(filename)));
+        }
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(ListEndPoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/directory/CopyDirectoryEndpointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/directory/CopyDirectoryEndpointTest.java
@@ -1,0 +1,166 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.directory;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class CopyDirectoryEndpointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a proper request to CopyDirectoryEndpoint results in a correct response and a directory being saved to disk.
+    public void httpCopyDirectoryTest() {
+        // Source directory must exist
+        final Path sourceDirectory = notebookDirectory().resolve(directory1());
+        Assertions.assertTrue(Files.exists(sourceDirectory));
+        final List<Path> sourceDirectoryChildren = Assertions
+                .assertDoesNotThrow(() -> Files.list(sourceDirectory))
+                .map(path -> path.getFileName())
+                .collect(Collectors.toList());
+
+        // Destination directory must not exist
+        final Path destinationDirectory = Paths.get("testDirectory");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationDirectory)));
+
+        final CopyDirectoryEndpoint endPoint = new CopyDirectoryEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final JsonObject body = Json.createObjectBuilder().add("sourcePath", directory1().toString()).build();
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(Paths.get(destinationDirectory.toString())), new JSONBody(body)));
+
+        // Assert that we receive the proper response.
+        final JsonArrayBuilder expectedChildren = Json.createArrayBuilder();
+        expectedChildren.add(notebook1().getFileName().toString());
+        final JsonObject expectedJson = Json.createObjectBuilder().build();
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", destinationDirectory.toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(response.body().asString(), expectedJson.toString()));
+
+        // Destination directory must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(destinationDirectory)));
+        // Destination directory must contain same list of files as Source directory
+        final List<Path> destinationDirectoryChildren = Assertions
+                .assertDoesNotThrow(() -> Files.list(notebookDirectory().resolve(destinationDirectory)))
+                .map(path -> path.getFileName())
+                .collect(Collectors.toList());
+        Assertions.assertEquals(sourceDirectoryChildren, destinationDirectoryChildren);
+        // Source directory must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(directory1())));
+    }
+
+    @Test
+    // Assert that a request to CopyDirectoryEndpoint with a source path that does not have any saved file results in an error
+    public void httpCopyNonExistentSourceDirectoryTest() {
+        // Source directory not must exist
+        final Path sourceDirectory = Paths.get("I_DONT_EXIST");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(sourceDirectory)));
+
+        // Destination directory must not exist
+        final Path destinationDirectory = Paths.get("testDirectory");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationDirectory)));
+
+        final CopyDirectoryEndpoint endPoint = new CopyDirectoryEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final JsonObject body = Json.createObjectBuilder().add("sourcePath", sourceDirectory.toString()).build();
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(destinationDirectory), new JSONBody(body)));
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+
+        // Assert that the file was not created.
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationDirectory)));
+    }
+
+    @Test
+    // Assert that a request to CopyDirectoryEndpoint to a path that already contains a directory results in an error
+    public void httpCopyDirectoryIntoUnavailablePathTest() {
+        // Source directory must exist
+        final Path sourceDirectory = directory2();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(sourceDirectory)));
+
+        // Destination directory must exist
+        final Path destinationDirectoryName = directory1();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(destinationDirectoryName)));
+
+        final CopyDirectoryEndpoint endPoint = new CopyDirectoryEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final JsonObject body = Json.createObjectBuilder().add("sourcePath", directory2().toString()).build();
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(directory1()), new JSONBody(body)));
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(CopyDirectoryEndpoint.class).verify();
+    }
+
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/directory/CreateDirectoryEndpointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/directory/CreateDirectoryEndpointTest.java
@@ -1,0 +1,118 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.directory;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class CreateDirectoryEndpointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a proper request to CreateDirectoryEndpoint results in a correct response and a file being saved to disk.
+    public void httpCreateDirectoryTest() {
+        final Path newDirectoryPath = Paths.get("testDirectory");
+        // Destination directory must not exist
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(newDirectoryPath)));
+        final CreateDirectoryEndpoint endPoint = new CreateDirectoryEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(newDirectoryPath)));
+        // Assert that we receive the proper response.
+        final JsonObject expectedJson = Json.createObjectBuilder().build();
+
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", newDirectoryPath.toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Destination directory must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(newDirectoryPath)));
+    }
+
+    @Test
+    // Assert that a request to CreateDirectoryEndpoint to a path that already contains a file results in an error
+    public void httpCreateDirectoryIntoUnavailablePathTest() {
+        // Destination directory must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(directory1())));
+        final CreateDirectoryEndpoint endPoint = new CreateDirectoryEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(directory1())));
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Path at " + directory1() + " is already in use!")
+                .build();
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(CreateDirectoryEndpoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/directory/DeleteDirectoryEndPointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/directory/DeleteDirectoryEndPointTest.java
@@ -1,0 +1,87 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.directory;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class DeleteDirectoryEndPointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a HTTP request to /notebook/new endpoint results in new directory being saved on disk.
+    public void httpDeleteDirectoryTest() {
+        final Path deletedDirectoryPath = directory2();
+        // Destination directory must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(deletedDirectoryPath)));
+        final DeleteDirectoryEndpoint endPoint = new DeleteDirectoryEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(deletedDirectoryPath)));
+        // Assert that we receive the proper response.
+        Assertions.assertEquals(204, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", deletedDirectoryPath.toString());
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        // Destination directory must not exist
+        Assertions.assertFalse(Files.exists(deletedDirectoryPath));
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(DeleteDirectoryEndpoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/directory/FindDirectoryEndPointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/directory/FindDirectoryEndPointTest.java
@@ -1,0 +1,121 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.directory;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class FindDirectoryEndPointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a HTTP request to /directory/find endpoint results in a response with the expected file contents
+    public void httpFindTest() {
+        // Destination directory must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(directory2())));
+
+        final String expectedFileContent = "{\"title\":\"my_second_folder_2A94M5J2D\",\"children\":[\""
+                + notebook1().getFileName() + "\"]}";
+
+        final FindDirectoryEndPoint endPoint = new FindDirectoryEndPoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(directory2())));
+        Assertions.assertEquals(HttpStatus.OK_200, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", directory2().toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions.assertDoesNotThrow(() -> Assertions.assertEquals(expectedFileContent, response.body().asString()));
+    }
+
+    @Test
+    public void httpDirectoryNotFoundTest() {
+
+        // Destination directory must not exist
+        final Path nonExistentPath = Paths.get("nonExistentPath");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(nonExistentPath)));
+
+        final FindDirectoryEndPoint endPoint = new FindDirectoryEndPoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(nonExistentPath)));
+
+        // The endpoint should return a response with the correct status and message
+
+        final JsonObject expectedResponse = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + nonExistentPath)
+                .build();
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertEquals(expectedResponse.toString(), response.body().asString())
+                );
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(FindDirectoryEndPoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/notebook/CopyNotebookEndpointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/notebook/CopyNotebookEndpointTest.java
@@ -1,0 +1,338 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.body.StringBody;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class CopyNotebookEndpointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a proper request to CopyNotebookEndpoint results in a correct response and a file being saved to disk.
+    public void httpCopyNotebookTest() {
+        // Destination file must not exist
+        final Path destinationFile = Paths.get("testNotebookName");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationFile)));
+
+        // Source file must exist
+        final Path sourceFile = notebook2();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(sourceFile)));
+        final String sourceFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(sourceFile)));
+
+        final CopyNotebookEndpoint endPoint = new CopyNotebookEndpoint(new LocalFilesystemStorage(notebookDirectory()));
+        final JsonObject body = Json.createObjectBuilder().add("sourcePath", notebook2().toString()).build();
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(destinationFile), new JSONBody(body)));
+
+        // Assert that we receive the proper response and that it contains the text from all the paragraphs from the source notebook
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", destinationFile.toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions
+                                .assertTrue(
+                                        response
+                                                .body()
+                                                .asString()
+                                                .contains(
+                                                        "\"script\":{\"text\":\"%test\\n## Congratulations, it's done.\\n##### You can create your own notebook in 'Notebook' menu. Good luck!\"}"
+                                                )
+                                )
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions
+                                .assertTrue(
+                                        response
+                                                .body()
+                                                .asString()
+                                                .contains(
+                                                        "\"script\":{\"text\":\"%test\\n\\nAbout bank data\\n\\n```\\nCitation Request:\\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \\n  Please include this citation if you plan to use this database:\\n\\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \\n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM'2011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\\n\\n  Available at: [pdf] http://hdl.handle.net/1822/14838\\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\\n```\"}"
+                                                )
+                                )
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().contains("\"script\":{\"text\":\"\"}"))
+                );
+        // Assert that the copied file was created to proper path.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(destinationFile)));
+        // Source file must not have changed
+        Assertions
+                .assertEquals(
+                        sourceFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())))
+                );
+    }
+
+    @Test
+    // Assert that a request with no Body to CopyNotebookEndpoint results in an error
+    public void httpCopyNotebookWithNoBodyTest() {
+        // Destination file must not exist
+        final Path destinationFile = Paths.get("testNotebookName");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationFile)));
+
+        // Source file must exist
+        final Path sourceFile = notebook2();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(sourceFile)));
+        final String sourceFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(sourceFile)));
+
+        final CopyNotebookEndpoint endPoint = new CopyNotebookEndpoint(new LocalFilesystemStorage(notebookDirectory()));
+        // Send a request with no Body
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(destinationFile)));
+
+        // Assert that we receive the proper response
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Request does not contain a sourceidentifier!")
+                .build();
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Assert that the no file was copied.
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationFile)));
+        // Source file must not have changed
+        Assertions
+                .assertEquals(
+                        sourceFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())))
+                );
+    }
+
+    @Test
+    // Assert that a request with no Body to CopyNotebookEndpoint results in an error
+    public void httpCopyNotebookWithMalformedBodyTest() {
+        // Destination file must not exist
+        final Path destinationFile = Paths.get("testNotebookName");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationFile)));
+
+        // Source file must exist
+        final Path sourceFile = notebook2();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(sourceFile)));
+        final String sourceFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(sourceFile)));
+
+        final CopyNotebookEndpoint endPoint = new CopyNotebookEndpoint(new LocalFilesystemStorage(notebookDirectory()));
+        // Send a request with malformed Body
+        final String bodyString = "{\"whoops i forgot to format the JSON\"\"true\"}";
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(destinationFile), new StringBody(bodyString)));
+
+        // Assert that we receive the proper response
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Request does not contain a sourceidentifier!")
+                .build();
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Assert that the no file was copied.
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationFile)));
+        // Source file must not have changed
+        Assertions
+                .assertEquals(
+                        sourceFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())))
+                );
+    }
+
+    @Test
+    // Assert that a proper request to CopyNotebookEndpoint results in a correct response and a file being overwritten to disk.
+    public void httpCopyAndOverwriteNotebookTest() {
+        // Destination file must exist
+        final Path destinationFile = notebook3();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(destinationFile)));
+        final String destinationFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(destinationFile)));
+
+        // Source file must exist
+        final Path sourceFile = notebook2();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(sourceFile)));
+        final String sourceFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(sourceFile)));
+
+        final CopyNotebookEndpoint endPoint = new CopyNotebookEndpoint(new LocalFilesystemStorage(notebookDirectory()));
+        final JsonObject body = Json.createObjectBuilder().add("sourcePath", notebook2().toString()).build();
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(destinationFile), new JSONBody(body)));
+
+        // Assert that we receive the proper response and that it contains the text from all the paragraphs from the source notebook
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", notebook3().toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions
+                                .assertTrue(
+                                        response
+                                                .body()
+                                                .asString()
+                                                .contains(
+                                                        "\"script\":{\"text\":\"%test\\n## Congratulations, it's done.\\n##### You can create your own notebook in 'Notebook' menu. Good luck!\"}"
+                                                )
+                                )
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions
+                                .assertTrue(
+                                        response
+                                                .body()
+                                                .asString()
+                                                .contains(
+                                                        "\"script\":{\"text\":\"%test\\n\\nAbout bank data\\n\\n```\\nCitation Request:\\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \\n  Please include this citation if you plan to use this database:\\n\\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \\n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM'2011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\\n\\n  Available at: [pdf] http://hdl.handle.net/1822/14838\\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\\n```\"}"
+                                                )
+                                )
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().contains("\"script\":{\"text\":\"\"}"))
+                );
+        // Assert that the copied file was created to proper path.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(destinationFile)));
+        // Source file must not have changed
+        Assertions
+                .assertEquals(
+                        sourceFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(sourceFile)))
+                );
+        // Destination file must have changed
+        Assertions
+                .assertNotEquals(
+                        destinationFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(destinationFile)))
+                );
+    }
+
+    @Test
+    // Assert that a request to CopyNotebookEndpoint with a source path that does not have a file results in an error
+    public void httpCopyNonExistentSourceNotebookTest() {
+        // Destination file must not exist
+        final Path destinationFile = Paths.get("testNotebookName");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationFile)));
+
+        // Source file must not exist
+        final Path sourceFile = Paths.get("I_DONT_EXIST");
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(sourceFile)));
+
+        final CopyNotebookEndpoint endPoint = new CopyNotebookEndpoint(new LocalFilesystemStorage(notebookDirectory()));
+        final JsonObject body = Json.createObjectBuilder().add("sourcePath", sourceFile.toString()).build();
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(destinationFile), new JSONBody(body)));
+
+        // The endpoint should return an JsonResponse with the correct status and specified cause.
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        // Assert that the file was not created.
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(destinationFile)));
+    }
+
+    @Test
+    // Assert that a request to CopyNotebookEndpoint to a path that contains a directory results in an error
+    public void httpCopyNotebookIntoUnavailablePathTest() {
+        // Destination file must exist and be a directory
+        final Path destinationDirectory = directory1();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(destinationDirectory)));
+        Assertions.assertTrue(Files.isDirectory(notebookDirectory().resolve(destinationDirectory)));
+
+        // Source file must exist
+        final Path sourceFile = notebook1();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(sourceFile)));
+        final String sourceFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(sourceFile)));
+
+        final CopyNotebookEndpoint endPoint = new CopyNotebookEndpoint(new LocalFilesystemStorage(notebookDirectory()));
+        final JsonObject body = Json.createObjectBuilder().add("sourcePath", sourceFile.toString()).build();
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(destinationDirectory), new JSONBody(body)));
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "File at path: " + directory1() + " is a Directory!")
+                .build();
+
+        // The endpoint should return an JsonResponse with the correct status and specified cause.
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions.assertEquals(expectedJson.toString(), response.body().asString());
+
+        // Source file must not have changed
+        Assertions
+                .assertEquals(
+                        sourceFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(sourceFile)))
+                );
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(CopyNotebookEndpoint.class).verify();
+    }
+
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/notebook/CreateNotebookEndpointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/notebook/CreateNotebookEndpointTest.java
@@ -1,0 +1,173 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class CreateNotebookEndpointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a proper request to CreateNotebookEndpoint results in a correct response and a file being saved to disk.
+    public void httpCreateNotebookTest() {
+        final Path newNotebookPath = Paths.get("testNotebook");
+        // Destination notebook must not exist
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(newNotebookPath)));
+
+        final CreateNotebookEndpoint endPoint = new CreateNotebookEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(newNotebookPath)));
+        // Assert that we receive the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("title", "")
+                .add("config", Json.createObjectBuilder().build())
+                .add("paragraphs", Json.createArrayBuilder())
+                .build();
+
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", newNotebookPath.toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Destination notebook must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(newNotebookPath)));
+    }
+
+    @Test
+    // Assert that a proper request to CreateNotebookEndpoint with a specified title in request body results in a correct response and a file being saved to disk.
+    public void httpCreateNotebookWithTitleTest() {
+        final Path newNotebookPath = Paths.get("testNotebook");
+        // Destination notebook must not exist
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(newNotebookPath)));
+
+        final String title = "newNotebook";
+        final CreateNotebookEndpoint endPoint = new CreateNotebookEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final JsonObject body = Json.createObjectBuilder().add("title", title).build();
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(newNotebookPath), new JSONBody(body)));
+        // Assert that we receive the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("title", title)
+                .add("config", Json.createObjectBuilder().build())
+                .add("paragraphs", Json.createArrayBuilder())
+                .build();
+
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", newNotebookPath.toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Assert that the file was created.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(newNotebookPath)));
+    }
+
+    @Test
+    // Assert that a request to CreateNotebookEndpoint to a path that already contains a Directory results in an error
+    public void httpCreateAndOverwriteNotebookTest() {
+        // Destination notebook must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook2())));
+        final String originalFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())));
+        final CreateNotebookEndpoint endPoint = new CreateNotebookEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(notebook2())));
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final String editedFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())));
+        // Destination file must have changed.
+        Assertions.assertNotEquals(originalFileContent, editedFileContent);
+
+    }
+
+    @Test
+    // Assert that a request to CreateNotebookEndpoint to a path that already contains a Directory results in an error
+    public void httpCreateNotebookIntoUnavailablePathTest() {
+        // Destination notebook must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(directory1())));
+        Assertions.assertTrue(Files.isDirectory(notebookDirectory().resolve(directory1())));
+        final CreateNotebookEndpoint endPoint = new CreateNotebookEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(directory1())));
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(CreateNotebookEndpoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/notebook/DeleteNotebookEndPointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/notebook/DeleteNotebookEndPointTest.java
@@ -1,0 +1,89 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.endpoints.directory.DeleteDirectoryEndpoint;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+
+public class DeleteNotebookEndPointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a HTTP request to /notebook/new endpoint results in a new file being saved on disk.
+    public void httpDeleteNotebookTest() {
+        // Assert that the file we are creating doesn't already exist.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook3())));
+        final DeleteNotebookEndpoint endPoint = new DeleteNotebookEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(notebook3())));
+        // Assert that we receive the proper response.
+        final Header expectedLocationHeader = new BasicHeader("Location", notebook3().toString());
+        Assertions.assertEquals(204, response.status());
+        Assertions.assertEquals(1, response.headers().size());
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        // Assert that Response should not hava a body.
+        Assertions.assertTrue(response.body().isStub());
+        // Assert that the file was created.
+        Assertions.assertFalse(Files.exists(notebookDirectory().resolve(notebook3())));
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(DeleteDirectoryEndpoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/notebook/FindNotebookEndPointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/notebook/FindNotebookEndPointTest.java
@@ -1,0 +1,174 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class FindNotebookEndPointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a HTTP GET request to /notebook/{path/to/notebook} endpoint results in a response with the expected file contents
+    public void httpFindTest() {
+        // Destination notebook must exist
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook1())));
+        final String expectedFileContent = "\"title\":\"my_note1\",\"config\":{}";
+
+        final FindNotebookEndPoint endPoint = new FindNotebookEndPoint(new LocalFilesystemStorage(notebookDirectory()));
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(notebook1())));
+        final Header expectedLocationHeader = new BasicHeader("Location", notebook1().toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(expectedFileContent))
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(notebook1Paragraph1()))
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(notebook1Paragraph2()))
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(notebook1Paragraph3()))
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(notebook1Paragraph4()))
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(notebook1Paragraph5()))
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(notebook1Paragraph6()))
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(notebook1Paragraph7()))
+                );
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertTrue(response.body().asString().strip().contains(notebook1Paragraph8()))
+                );
+    }
+
+    // Assert that a HTTP GET request to /notebook/{path/to/notebook} endpoint with a path not corresponding with any file results in an error
+    @Test
+    public void httpNotebookNotFoundTest() {
+        final Path nonExistentNotebookPath = Paths.get("nonExistentNotebook");
+        // Start server and wait for it to initialize.
+        final FindNotebookEndPoint endPoint = new FindNotebookEndPoint(new LocalFilesystemStorage(notebookDirectory()));
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(nonExistentNotebookPath)));
+
+        // The endpoint should return the correct status and message.
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + nonExistentNotebookPath)
+                .build();
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    // Assert that a HTTP GET request to /notebook/{path/to/notebook} endpoint with a path to a malformed / corrupted file results in an error message directing users to check details from logs.
+    @Test
+    public void httpFindCorruptNotebookTest() {
+        final Path nonExistentNotebookPath = Paths.get("junkfile");
+        final FindNotebookEndPoint endPoint = new FindNotebookEndPoint(new LocalFilesystemStorage(notebookDirectory()));
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(nonExistentNotebookPath)));
+
+        // The endpoint should return the correct status and message.
+        Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.status());
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions
+                                .assertTrue(
+                                        response
+                                                .body()
+                                                .asString()
+                                                .contains(
+                                                        "An error occurred while processing your Request. See event id "
+                                                )
+                                )
+                );
+
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions
+                                .assertTrue(response.body().asString().contains(" in the technical log for details."))
+                );
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(FindNotebookEndPoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/notebook/UpdateNotebookEndpointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/notebook/UpdateNotebookEndpointTest.java
@@ -1,0 +1,132 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.notebook;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.path.HTTPBasicRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class UpdateNotebookEndpointTest extends AbstractNotebookServerTest {
+
+    @Test
+    public void httpUpdateNotebookTest() {
+        // Destination notebook must exist
+        final Path notebookPath = notebook2();
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebookPath)));
+        // Make a request editing the title of the notebook.
+        final String editedTitle = "testTitle";
+        final UpdateNotebookEndpoint endpoint = new UpdateNotebookEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final JsonObject body = Json.createObjectBuilder().add("title", editedTitle).build();
+        final HTTPResponse response = endpoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(notebookPath), new JSONBody(body)));
+
+        // Assert that we got the proper response.
+        Assertions.assertEquals(HttpStatus.OK_200, response.status());
+        final Header expectedLocationHeader = new BasicHeader("Location", notebookPath.toString());
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions.assertDoesNotThrow(() -> Assertions.assertTrue(response.body().asString().contains(editedTitle)));
+
+        final String updatedFileContent = Assertions
+                .assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())));
+        // Assert that the notebook title has been saved to the file in the correct place.
+        final String expectedFileContent = "{\"title\":\"" + editedTitle
+                + "\",\"config\":{},\"paragraphs\":[{\"id\":\"20150213-230428_1231780373\",\"title\":\"\",\"script\":{\"text\":\"%test\\n## Congratulations, it's done.\\n##### You can create your own notebook in 'Notebook' menu. Good luck!\"}},{\"id\":\"20150326-214658_12335843\",\"title\":\"\",\"script\":{\"text\":\"%test\\n\\nAbout bank data\\n\\n```\\nCitation Request:\\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \\n  Please include this citation if you plan to use this database:\\n\\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \\n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM'2011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\\n\\n  Available at: [pdf] http://hdl.handle.net/1822/14838\\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\\n```\"}},{\"id\":\"20150703-133047_853701097\",\"title\":\"\",\"script\":{\"text\":\"\"}}]}";
+        Assertions.assertEquals(expectedFileContent, updatedFileContent);
+    }
+
+    // Assert that trying to update a nonexistent notebook results in an error.
+    @Test
+    public void httpUpdateNonexistentNotebookTest() {
+        final Path nonExistentNotebookPath = notebookDirectory().resolve("nonExistentNotebook");
+
+        // Destination notebook must not exist
+        Assertions.assertFalse(Files.exists(nonExistentNotebookPath));
+
+        final String editedTitle = "testTitle";
+        final UpdateNotebookEndpoint endpoint = new UpdateNotebookEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final JsonObject body = Json.createObjectBuilder().add("title", editedTitle).build();
+        final HTTPResponse response = endpoint
+                .createResponse(new BasicHTTPRequest(new HTTPBasicRequestPath(nonExistentNotebookPath), new JSONBody(body)));
+        // Assert that we got the proper response.
+
+        // The endpoint should return an JsonResponse with the correct status and specified cause.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + nonExistentNotebookPath)
+                .build();
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(UpdateNotebookEndpoint.class).verify();
+    }
+
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/CopyParagraphEndpointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/CopyParagraphEndpointTest.java
@@ -1,0 +1,377 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.google.common.base.Charsets;
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.path.HTTPParagraphRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class CopyParagraphEndpointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a HTTP request to CopyParagraphEndpoint results in an updated file with the contents of the copied paragraph being saved on disk.
+    public void httpCopyParagraphTest() {
+        final Path destinationNotebookPath = notebookDirectory().resolve(notebook1());
+        final String destinationParagraphId = "copyParagraph";
+        final Path sourceNotebookPath = notebookDirectory().resolve(notebook3());
+        final String sourceParagraphId = "20150213-230428_1231780373";
+        // Source and Destination files should exist.
+        Assertions.assertTrue(Files.exists(destinationNotebookPath));
+        Assertions.assertTrue(Files.exists(sourceNotebookPath));
+
+        // Assert that the paragraph text is contained in the sourceNotebook but not in the destinationNotebook
+        final String expectedParagraphContent = "\"text\":\"%test\\n## Hello, I'm a new notebook. Totally different to the previous one, I have one less paragraphs, you see.\\n##### You can create your own notebook in 'Notebook' menu. Good luck!\"";
+        // Read file contents into a JSON object to handle unicode escaping that is present in the test files.
+        final JsonObject sourceFileObject = readFileContents(sourceNotebookPath);
+        final JsonObject originalDestinationFileObject = readFileContents(destinationNotebookPath);
+        Assertions.assertTrue(sourceFileObject.toString().contains(expectedParagraphContent));
+        Assertions.assertFalse(originalDestinationFileObject.toString().contains(expectedParagraphContent));
+
+        final CopyParagraphEndpoint endPoint = new CopyParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final Path requestPath = Paths.get(notebook1().toString(), destinationParagraphId);
+
+        final JsonObject body = Json
+                .createObjectBuilder()
+                .add("sourcePath", notebook3().toString())
+                .add("sourceParagraphId", sourceParagraphId)
+                .build();
+        final BasicHTTPRequest request = new BasicHTTPRequest(
+                new HTTPParagraphRequestPath(requestPath),
+                new JSONBody(body)
+        );
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // Assert that we receive the proper response.
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final Header expectedLocationHeader = new BasicHeader(
+                "Location",
+                requestPath.subpath(0, requestPath.getNameCount() - 1).toString()
+        );
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions
+                                .assertTrue(
+                                        response
+                                                .body()
+                                                .asString()
+                                                .contains(
+                                                        "\"script\":{\"text\":\"%test\\n## Hello, I'm a new notebook. Totally different to the previous one, I have one less paragraphs, you see.\\n##### You can create your own notebook in 'Notebook' menu. Good luck!\"}"
+                                                )
+                                )
+                );
+
+        // Assert that the paragraph content exists in the destination file after the operation is complete.
+        final JsonObject destinationFileObject = readFileContents(destinationNotebookPath);
+        Assertions
+                .assertTrue(
+                        destinationFileObject
+                                .toString()
+                                .contains(new String(expectedParagraphContent.getBytes(), Charsets.UTF_8))
+                );
+    }
+
+    @Test
+    // Assert that a HTTP request to CopyParagraphEndpoint with an incorrect source paragraph id results in an error.
+    public void httpCopyParagraphWithIncorrectSourceParagraphIdTest() {
+        final Path destinationNotebookPath = notebookDirectory().resolve(notebook1());
+        final String destinationParagraphId = "copyParagraph";
+        final Path sourceNotebookPath = notebookDirectory().resolve(notebook3());
+        final String sourceParagraphId = "I_DON'T_EXIST";
+
+        // Source and Destination files must exist.
+        Assertions.assertTrue(Files.exists(destinationNotebookPath));
+        Assertions.assertTrue(Files.exists(sourceNotebookPath));
+
+        // Assert that the paragraph ID we are looking for is not contained in the sourceNotebook
+        final String expectedParagraphContent = "I_DON'T_EXIST";
+        // Read file contents into a JSON object to handle unicode escaping that is present in the test files.
+        final JsonObject sourceFileObject = readFileContents(sourceNotebookPath);
+        Assertions.assertFalse(sourceFileObject.toString().contains(expectedParagraphContent));
+
+        final CopyParagraphEndpoint endPoint = new CopyParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final Path requestPath = Paths.get(notebook1().toString(), destinationParagraphId);
+        final JsonObject body = Json
+                .createObjectBuilder()
+                .add("sourcePath", notebook3().toString())
+                .add("sourceParagraphId", sourceParagraphId)
+                .build();
+        final BasicHTTPRequest request = new BasicHTTPRequest(
+                new HTTPParagraphRequestPath(requestPath),
+                new JSONBody(body)
+        );
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // Assert that we receive the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such paragraph: " + sourceParagraphId + "!")
+                .build();
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+
+        // Assert that the paragraph content does not exist in the destination file after the operation is complete.
+        final JsonObject destinationFileObject = readFileContents(destinationNotebookPath);
+        Assertions
+                .assertFalse(
+                        destinationFileObject
+                                .toString()
+                                .contains(new String(expectedParagraphContent.getBytes(), Charsets.UTF_8))
+                );
+    }
+
+    @Test
+    // Assert that a HTTP request to CopyParagraphEndpoint with no source paragraph id results in an error
+    public void httpCopyParagraphWithNoSourceParagraphId() {
+        final String destinationParagraphId = "copyParagraph";
+        final Path sourceNotebookPath = notebookDirectory().resolve(notebook3());
+        // Source path must exist
+        Assertions.assertTrue(Files.exists(sourceNotebookPath));
+
+        final CopyParagraphEndpoint endPoint = new CopyParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final Path requestPath = Paths.get(notebook1().toString(), destinationParagraphId);
+        final JsonObject body = Json.createObjectBuilder().add("sourcePath", notebook3().toString()).build();
+        final BasicHTTPRequest request = new BasicHTTPRequest(
+                new HTTPParagraphRequestPath(requestPath),
+                new JSONBody(body)
+        );
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // Assert that we receive the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Request does not contain a SourceParagraphId!")
+                .build();
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    // Assert that a HTTP request to CopyParagraphEndpoint results in an updated file with the contents of the copied paragraph being saved on disk.
+    public void httpCopyParagraphWithIncorrectSourcePathTest() {
+        final String destinationParagraphId = "copyParagraph";
+        final String sourceNotebookName = "I_DONT_EXIST";
+        final Path sourceNotebookPath = Paths.get(sourceNotebookName);
+        final String sourceParagraphId = "20150213-230428_1231780373";
+        // Source path must not exist
+        Assertions.assertFalse(Files.exists(sourceNotebookPath));
+
+        final CopyParagraphEndpoint endPoint = new CopyParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final Path requestPath = Paths.get(notebook1().toString(), destinationParagraphId);
+        final JsonObject body = Json
+                .createObjectBuilder()
+                .add("sourcePath", sourceNotebookName)
+                .add("sourceParagraphId", sourceParagraphId)
+                .build();
+        final BasicHTTPRequest request = new BasicHTTPRequest(
+                new HTTPParagraphRequestPath(requestPath),
+                new JSONBody(body)
+        );
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // Assert that we receive the proper response.
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + sourceNotebookName)
+                .build();
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    // Assert that a HTTP request to CopyParagraphEndpoint results in an updated file with the contents of the copied paragraph being saved on disk.
+    public void httpCopyParagraphWithNoSourcePathTest() {
+        final String destinationParagraphId = "copyParagraph";
+        final String sourceParagraphId = "20150213-230428_1231780373";
+
+        final CopyParagraphEndpoint endPoint = new CopyParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final Path requestPath = Paths.get(notebook1().toString(), destinationParagraphId);
+        final JsonObject body = Json.createObjectBuilder().add("sourceParagraphId", sourceParagraphId).build();
+        final BasicHTTPRequest request = new BasicHTTPRequest(
+                new HTTPParagraphRequestPath(requestPath),
+                new JSONBody(body)
+        );
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // Assert that we receive the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Request does not contain a sourceidentifier!")
+                .build();
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    // Assert that a HTTP request to CopyParagraphEndpoint with a sourceId that already exists results in an error.
+    public void httpCopyParagraphIntoExistingParagraphIdTest() {
+        final Path destinationNotebookPath = notebookDirectory().resolve(notebook1());
+        final String destinationParagraphId = "20150213-231621_168813393";
+        final Path sourceNotebookPath = notebookDirectory().resolve(notebook3());
+        final String sourceParagraphId = "20150213-230428_1231780373";
+        // Source and destination paths must exist
+        Assertions.assertTrue(Files.exists(destinationNotebookPath));
+        Assertions.assertTrue(Files.exists(sourceNotebookPath));
+
+        // Assert that the paragraph id is already contained in the destinationNotebook
+        // Read file contents into a JSON object to handle unicode escaping that is present in the test files.
+        final JsonObject originalDestinationFileObject = readFileContents(destinationNotebookPath);
+        Assertions.assertTrue(originalDestinationFileObject.toString().contains(destinationParagraphId));
+
+        final CopyParagraphEndpoint endPoint = new CopyParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final Path requestPath = Paths.get(notebook1().toString(), destinationParagraphId);
+        final JsonObject body = Json
+                .createObjectBuilder()
+                .add("sourcePath", notebook3().toString())
+                .add("sourceParagraphId", sourceParagraphId)
+                .build();
+        final BasicHTTPRequest request = new BasicHTTPRequest(
+                new HTTPParagraphRequestPath(requestPath),
+                new JSONBody(body)
+        );
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // Assert that we receive the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Paragraph " + destinationParagraphId + " already exists!")
+                .build();
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    // Assert that a HTTP request to CopyParagraphEndpoint results in an updated file with the contents of the copied paragraph being saved on disk.
+    public void httpCopyParagraphIntoIncorrectDestinationPathTest() {
+        final Path destinationNotebookPath = Paths.get("I_DONT_EXIST");
+        final String destinationParagraphId = "copyParagraph";
+        final Path sourceNotebookPath = notebookDirectory().resolve(notebook3());
+        final String sourceParagraphId = "20150213-230428_1231780373";
+        // Source path must exist, but destination past must not
+        Assertions.assertFalse(Files.exists(destinationNotebookPath));
+        Assertions.assertTrue(Files.exists(sourceNotebookPath));
+
+        final CopyParagraphEndpoint endPoint = new CopyParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final Path requestPath = Paths.get(destinationNotebookPath.toString(), destinationParagraphId);
+        final JsonObject body = Json
+                .createObjectBuilder()
+                .add("sourcePath", notebook3().toString())
+                .add("sourceParagraphId", sourceParagraphId)
+                .build();
+        final BasicHTTPRequest request = new BasicHTTPRequest(
+                new HTTPParagraphRequestPath(requestPath),
+                new JSONBody(body)
+        );
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // Assert that we receive the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + destinationNotebookPath)
+                .build();
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    private JsonObject readFileContents(final Path filePath) {
+        final String fileContent = Assertions.assertDoesNotThrow(() -> Files.readString(filePath));
+        final StringReader stringReader = new StringReader(fileContent);
+        final JsonReader jsonReader = Json.createReader(stringReader);
+        final JsonObject destinationFileObject = jsonReader.readObject();
+        stringReader.close();
+        jsonReader.close();
+        return destinationFileObject;
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/CreateParagraphEndPointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/CreateParagraphEndPointTest.java
@@ -1,0 +1,144 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.path.HTTPParagraphRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class CreateParagraphEndPointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a HTTP request to CreateParagraphEndpoint results in a new file being saved on disk.
+    public void httpCreateParagraphTest() {
+        // Assert that the file we are creating doesn't already exist.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook3())));
+        final CreateParagraphEndpoint endPoint = new CreateParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final String paragraphId = "testParagraphId";
+
+        final Path requestPath = Paths.get(notebook3().toString(), paragraphId);
+        final BasicHTTPRequest request = new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath));
+        final HTTPResponse response = endPoint.createResponse(request);
+        // Assert that we receive the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("id", paragraphId)
+                .add("title", "")
+                .add("script", Json.createObjectBuilder().add("text", "").build())
+                .build();
+
+        Assertions.assertEquals(HttpStatus.CREATED_201, response.status());
+        final Header expectedLocationHeader = new BasicHeader(
+                "Location",
+                requestPath.subpath(0, requestPath.getNameCount() - 1).toString()
+        );
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Assert that the file was created.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook3())));
+        final String expectedFileContent = "{\"id\":\"" + paragraphId + "\",\"title\":\"\",\"script\":{\"text\":\"\"}}";
+        Assertions
+                .assertTrue(Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook3())).contains(expectedFileContent)));
+    }
+
+    @Test
+    // Assert that a HTTP request to /notebook/new endpoint with a path that alreday doesn't contain a file results in an error.
+    public void httpCreateParagraphInNonExistentPathTest() {
+
+        final String nonexistentFileName = "NonExistentFile";
+        final Path nonexistentFilePath = Paths.get(notebookDirectory().toString(), nonexistentFileName);
+        // Assert that the file we are trying to add a paragraph to doesn't exist.
+        Assertions.assertFalse(Files.exists(nonexistentFilePath));
+        final CreateParagraphEndpoint endPoint = new CreateParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final String paragraphId = "testParagraphId";
+
+        final Path requestPath = Paths.get(nonexistentFileName, paragraphId);
+        final JsonObject body = Json.createObjectBuilder().add("paragraphId", paragraphId).build();
+        final BasicHTTPRequest request = new BasicHTTPRequest(
+                new HTTPParagraphRequestPath(requestPath),
+                new JSONBody(body)
+        );
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // The endpoint should return an JsonResponse with the correct status and specified cause.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + nonexistentFileName)
+                .build();
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(CreateParagraphEndpoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/DeleteParagraphEndPointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/DeleteParagraphEndPointTest.java
@@ -1,0 +1,158 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.path.HTTPParagraphRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class DeleteParagraphEndPointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a request to DeleteParagraphEndpoint results in a file with edited content being saved on disk.
+    public void httpDeleteParagraphTest() {
+        // Assert that the file we are deleting from exists.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook3())));
+        final DeleteParagraphEndpoint endPoint = new DeleteParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final String paragraphId = "20150213-230428_1231780373";
+
+        final Path requestPath = Paths.get(notebook3().toString(), paragraphId);
+        final BasicHTTPRequest request = new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath));
+        final HTTPResponse response = endPoint.createResponse(request);
+        // Assert that we receive the proper response.
+        Assertions.assertEquals(HttpStatus.NO_CONTENT_204, response.status());
+        final Header expectedLocationHeader = new BasicHeader(
+                "Location",
+                requestPath.subpath(0, requestPath.getNameCount() - 1).toString()
+        );
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+
+        // Assert that the file was changed.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook3())));
+        final String expectedFileContent = "{\"title\":\"my_note2\",\"config\":{},\"paragraphs\":[]}";
+        Assertions
+                .assertEquals(
+                        expectedFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook3())))
+                );
+
+    }
+
+    @Test
+    // Assert that a request to DeleteParagraphEndpoint with an invalid paragraphId results in an error.
+    public void httpDeleteNonexistentParagraphTest() {
+        // Assert that the file we are deleting already exists.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook3())));
+        final String nonExistentParagraphId = "nonExistentParagraphId";
+        final DeleteParagraphEndpoint endPoint = new DeleteParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+
+        final Path requestPath = Paths.get(notebook3().toString(), nonExistentParagraphId);
+
+        final BasicHTTPRequest request = new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath));
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // The endpoint should return a Response with the correct status and message.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Paragraph " + nonExistentParagraphId + " doesn't exist!")
+                .build();
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    // Assert that a request to DeleteParagraphEndpoint a path to a nonexistent notebook results in an error.
+    public void httpDeleteParagraphFromNonexistentNotebookTest() {
+        // Assert that the file we are creating doesn't already exist.
+        final String nonExistentNotebookName = "nonExistentNotebook";
+        final Path nonExistentNotebookPath = Paths.get(notebookDirectory().toString(), nonExistentNotebookName);
+        Assertions.assertFalse(Files.exists(nonExistentNotebookPath));
+        final DeleteParagraphEndpoint endPoint = new DeleteParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final String paragraphId = "20150213-230428_1231780373";
+
+        final Path requestPath = Paths.get(nonExistentNotebookName, paragraphId);
+        final BasicHTTPRequest request = new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath));
+        final HTTPResponse response = endPoint.createResponse(request);
+
+        // The endpoint should return an JsonResponse with the correct status and specified cause.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + nonExistentNotebookName)
+                .build();
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(DeleteParagraphEndpoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/FindParagraphEndPointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/FindParagraphEndPointTest.java
@@ -1,0 +1,144 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.path.HTTPParagraphRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class FindParagraphEndPointTest extends AbstractNotebookServerTest {
+
+    @Test
+    // Assert that a HTTP request to /notebook/{path/to/notebook}/paragraph/{paragraphId} endpoint results in a response with the expected file contents
+    public void httpFindTest() {
+        // Assert that the file exists.
+        Assertions.assertTrue(Files.exists(notebookDirectory().resolve(notebook1())));
+        final String paragraphId = "20150210-015259_1403135953";
+
+        final Path requestPath = Paths.get(notebook1().toString(), paragraphId);
+        final FindParagraphEndPoint endPoint = new FindParagraphEndPoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath)));
+        final Header expectedLocationHeader = new BasicHeader(
+                "Location",
+                requestPath.subpath(0, requestPath.getNameCount() - 1).toString()
+        );
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+        final String expectedFileContent = "{\"id\":\"20150210-015259_1403135953\",\"title\":\"Load data into table\",\"script\":{\"text\":\"%test import org.apache.commons.io.IOUtils\\nimport java.net.URL\\nimport java.nio.charset.Charset\\n\\n// Zeppelin creates and injects sc (SparkContext) and sqlContext (HiveContext or SqlContext)\\n// So you don't need create them manually\\n\\n// load bank data\\nval bankText = sc.parallelize(\\n    IOUtils.toString(\\n        new URL(\\\"https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv\\\"),\\n        Charset.forName(\\\"utf8\\\")).split(\\\"\\\\n\\\"))\\n\\ncase class Bank(age: Integer, job: String, marital: String, education: String, balance: Integer)\\n\\nval bank = bankText.map(s => s.split(\\\";\\\")).filter(s => s(0) != \\\"\\\\\\\"age\\\\\\\"\\\").map(\\n    s => Bank(s(0).toInt, \\n            s(1).replaceAll(\\\"\\\\\\\"\\\", \\\"\\\"),\\n            s(2).replaceAll(\\\"\\\\\\\"\\\", \\\"\\\"),\\n            s(3).replaceAll(\\\"\\\\\\\"\\\", \\\"\\\"),\\n            s(5).replaceAll(\\\"\\\\\\\"\\\", \\\"\\\").toInt\\n        )\\n).toDF()\\nbank.registerTempTable(\\\"bank\\\")\"}}";
+        Assertions
+                .assertDoesNotThrow(
+                        () -> Assertions.assertEquals(expectedFileContent, response.body().asString().strip())
+                );
+    }
+
+    @Test
+    // Assert that a HTTP request to /notebook/{path/to/notebook}/paragraph/{paragraphId} endpoint with a nonexistent Notebook results in an error
+    public void httpFindParagraphFromNonExistentNotebookTest() {
+        final String nonExistentNotebookName = "NonExistentNotebook";
+        final FindParagraphEndPoint endPoint = new FindParagraphEndPoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+        final String paragraphId = "20150210-015259_1403135953";
+
+        final Path requestPath = Paths.get(nonExistentNotebookName, paragraphId);
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath)));
+
+        // The endpoint should return a Response with the correct status and messagsse.
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + nonExistentNotebookName)
+                .build();
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    // Assert that a HTTP request to /notebook/{path/to/notebook}/paragraph/{paragraphId} endpoint with a nonexistent paragraphId results in an error
+    public void httpFindNonexistentParagraph() {
+        final String nonExistentParagraphId = "nonExistentParagraphId";
+        final FindParagraphEndPoint endPoint = new FindParagraphEndPoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+
+        final Path requestPath = Paths.get(notebook1().toString(), nonExistentParagraphId);
+        final HTTPResponse response = endPoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath)));
+
+        // The endpoint should return an JsonResponse with the correct status and specified cause.
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Paragraph with id " + nonExistentParagraphId + " not found!")
+                .build();
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(FindParagraphEndPoint.class).verify();
+    }
+}

--- a/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/UpdateParagraphEndpointTest.java
+++ b/src/test/java/com/teragrep/nbs_01/endpoints/paragraph/UpdateParagraphEndpointTest.java
@@ -1,0 +1,302 @@
+/*
+ * Notebook server for Teragrep Backend (nbs_01)
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nbs_01.endpoints.paragraph;
+
+import com.teragrep.nbs_01.AbstractNotebookServerTest;
+import com.teragrep.nbs_01.protocols.http.body.JSONBody;
+import com.teragrep.nbs_01.protocols.http.path.HTTPParagraphRequestPath;
+import com.teragrep.nbs_01.repository.storage.LocalFilesystemStorage;
+import com.teragrep.nbs_01.protocols.http.BasicHTTPRequest;
+import com.teragrep.nbs_01.protocols.http.HTTPResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class UpdateParagraphEndpointTest extends AbstractNotebookServerTest {
+
+    private final String paragraphId = "20150213-230428_1231780373";
+    private final String editedParagraphText = "test edit";
+    private final String editedTitle = "testTitle";
+
+    @Test
+    public void httpUpdateParagraphTest() {
+        // Assert that a request to UpdateParagraphEndpoint results in a modified file being saved on disk.
+        Assertions
+                .assertTrue(Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2()))).contains("%test\\n## Congratulations, it\\u0027s done.\\n##### You can create your own notebook in \\u0027Notebook\\u0027 menu. Good luck!"));
+
+        Assertions
+                .assertFalse(
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2()))).contains("\"title\":\"" + editedTitle + "\"")
+                );
+
+        final String expectedFileContent = "{\"title\":\"my_note2\",\"config\":{},\"paragraphs\":[{\"id\":\"20150213-230428_1231780373\",\"title\":\""
+                + editedTitle + "\",\"script\":{\"text\":\"" + editedParagraphText
+                + "\"}},{\"id\":\"20150326-214658_12335843\",\"title\":\"\",\"script\":{\"text\":\"%test\\n\\nAbout bank data\\n\\n```\\nCitation Request:\\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \\n  Please include this citation if you plan to use this database:\\n\\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \\n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM'2011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\\n\\n  Available at: [pdf] http://hdl.handle.net/1822/14838\\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\\n```\"}},{\"id\":\"20150703-133047_853701097\",\"title\":\"\",\"script\":{\"text\":\"\"}}]}";
+
+        // Make a request editing the title of the notebook as well as the text of a paragraph, identified with an ID.
+        final UpdateParagraphEndpoint endpoint = new UpdateParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+
+        final Path requestPath = Paths.get(notebook2().toString(), paragraphId);
+        final JsonObject body = Json
+                .createObjectBuilder()
+                .add("title", editedTitle)
+                .add("text", editedParagraphText)
+                .build();
+        final HTTPResponse response = endpoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath), new JSONBody(body)));
+        // Assert that we got the proper response.
+        Assertions.assertEquals(HttpStatus.OK_200, response.status());
+        final Header expectedLocationHeader = new BasicHeader(
+                "Location",
+                requestPath.subpath(0, requestPath.getNameCount() - 1).toString()
+        );
+        final Header expectedContentTypeHeader = new BasicHeader("Content-Type", "application/json");
+        Assertions.assertEquals(expectedLocationHeader.toString(), response.headers().get(0).toString());
+        Assertions.assertEquals(expectedContentTypeHeader.toString(), response.headers().get(1).toString());
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("id", paragraphId)
+                .add("title", editedTitle)
+                .add("script", Json.createObjectBuilder().add("text", editedParagraphText))
+                .build();
+
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Assert that the file content has the edited paragraph saved to file in the correct place.
+        Assertions
+                .assertEquals(
+                        expectedFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())))
+                );
+    }
+
+    @Test
+    public void httpUpdateParagraphTextTest() {
+        // Assert that a request to UpdateParagraphEndpoint results in a modified file where only the text has been changed being saved on disk.
+        Assertions
+                .assertTrue(Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2()))).contains("%test\\n## Congratulations, it\\u0027s done.\\n##### You can create your own notebook in \\u0027Notebook\\u0027 menu. Good luck!"));
+
+        final String expectedFileContent = "{\"title\":\"my_note2\",\"config\":{},\"paragraphs\":[{\"id\":\"20150213-230428_1231780373\",\"title\":\"\",\"script\":{\"text\":\""
+                + editedParagraphText
+                + "\"}},{\"id\":\"20150326-214658_12335843\",\"title\":\"\",\"script\":{\"text\":\"%test\\n\\nAbout bank data\\n\\n```\\nCitation Request:\\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \\n  Please include this citation if you plan to use this database:\\n\\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \\n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM'2011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\\n\\n  Available at: [pdf] http://hdl.handle.net/1822/14838\\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\\n```\"}},{\"id\":\"20150703-133047_853701097\",\"title\":\"\",\"script\":{\"text\":\"\"}}]}";
+
+        // Make a request editing the title of the notebook as well as the text of a paragraph, identified with an ID.
+        final UpdateParagraphEndpoint endpoint = new UpdateParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+
+        final Path requestPath = Paths.get(notebook2().toString(), paragraphId);
+        final JsonObject body = Json.createObjectBuilder().add("text", editedParagraphText).build();
+        final HTTPResponse response = endpoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath), new JSONBody(body)));
+        // Assert that we got the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("id", paragraphId)
+                .add("title", "")
+                .add("script", Json.createObjectBuilder().add("text", editedParagraphText))
+                .build();
+
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Assert that the file content has the edited paragraph saved to file in the correct place.
+        Assertions
+                .assertEquals(
+                        expectedFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())))
+                );
+    }
+
+    @Test
+    public void httpUpdateParagraphTitleTest() {
+        // Assert that a request to UpdateParagraphEndpoint results in a modified file where only the title has been changed being saved on disk.
+        Assertions
+                .assertFalse(
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2()))).contains("\"title\":\"" + editedTitle + "\"")
+                );
+
+        final String expectedFileContent = "{\"title\":\"my_note2\",\"config\":{},\"paragraphs\":[{\"id\":\"20150213-230428_1231780373\",\"title\":\""
+                + editedTitle
+                + "\",\"script\":{\"text\":\"%test\\n## Congratulations, it's done.\\n##### You can create your own notebook in 'Notebook' menu. Good luck!\"}},{\"id\":\"20150326-214658_12335843\",\"title\":\"\",\"script\":{\"text\":\"%test\\n\\nAbout bank data\\n\\n```\\nCitation Request:\\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \\n  Please include this citation if you plan to use this database:\\n\\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \\n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM'2011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\\n\\n  Available at: [pdf] http://hdl.handle.net/1822/14838\\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\\n```\"}},{\"id\":\"20150703-133047_853701097\",\"title\":\"\",\"script\":{\"text\":\"\"}}]}";
+
+        // Make a request editing the title of the notebook as well as the text of a paragraph, identified with an ID.
+        final UpdateParagraphEndpoint endpoint = new UpdateParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+
+        final Path requestPath = Paths.get(notebook2().toString(), paragraphId);
+        final JsonObject body = Json.createObjectBuilder().add("title", editedTitle).build();
+        final HTTPResponse response = endpoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath), new JSONBody(body)));
+        // Assert that we got the proper response.
+
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("id", paragraphId)
+                .add("title", editedTitle)
+                .add(
+                        "script",
+                        Json
+                                .createObjectBuilder()
+                                .add(
+                                        "text",
+                                        "%test\n## Congratulations, it's done.\n##### You can create your own notebook in 'Notebook' menu. Good luck!"
+                                )
+                )
+                .build();
+
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+        // Assert that the file content has the edited paragraph saved to file in the correct place.
+        Assertions
+                .assertEquals(
+                        expectedFileContent,
+                        Assertions.assertDoesNotThrow(() -> Files.readString(notebookDirectory().resolve(notebook2())))
+                );
+    }
+
+    @Test
+    public void httpUpdateParagraphInNonexistentNotebookTest() {
+        // Assert that a request to UpdateParagraphEndpoint with a nonexistent notebook path results in an error.
+        final String nonExistentNotebookName = "nonExistentNotebook";
+
+        // Make a request editing the title of a notebook that doesn't exist.
+        final UpdateParagraphEndpoint endpoint = new UpdateParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+
+        final Path requestPath = Paths.get(nonExistentNotebookName, paragraphId);
+        final JsonObject body = Json
+                .createObjectBuilder()
+                .add("title", editedTitle)
+                .add("text", editedParagraphText)
+                .build();
+        final HTTPResponse response = endpoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath), new JSONBody(body)));
+
+        // The endpoint should return a Response with the correct status and message.
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "No such file: " + nonExistentNotebookName)
+                .build();
+        Assertions.assertEquals(HttpStatus.NOT_FOUND_404, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    public void httpUpdateNonexistentParagraphTest() {
+        // Assert that a request to UpdateParagraphEndpoint with a nonexistent paragraphId results in an error.
+        final String nonexistentParagraphId = "nonexistentId";
+
+        // Make a request editing the title of the notebook as well as the text of a paragraph, identified with an ID.
+        final UpdateParagraphEndpoint endpoint = new UpdateParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+
+        final Path requestPath = Paths.get(notebook2().toString(), nonexistentParagraphId);
+        final JsonObject body = Json
+                .createObjectBuilder()
+                .add("title", editedTitle)
+                .add("paragraphId", nonexistentParagraphId)
+                .add("text", editedParagraphText)
+                .build();
+        final HTTPResponse response = endpoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath), new JSONBody(body)));
+
+        // The endpoint should return a Response with the correct status and message.
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Paragraph with Id " + nonexistentParagraphId + " not found!")
+                .build();
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    public void httpInvalidRequestFormatTest() {
+        // Assert that a request to UpdateParagraphEndpoint with an improperly formatted Request results in an error.
+        final String nonexistentNotebookName = "nonexistentNotebookPath";
+
+        // Make a request editing the title of the notebook as well as the text of a paragraph, identified with an ID.
+        final UpdateParagraphEndpoint endpoint = new UpdateParagraphEndpoint(
+                new LocalFilesystemStorage(notebookDirectory())
+        );
+
+        final Path requestPath = Paths.get(nonexistentNotebookName);
+        final JsonObject body = Json.createObjectBuilder().add("text", editedParagraphText).build();
+        final HTTPResponse response = endpoint
+                .createResponse(new BasicHTTPRequest(new HTTPParagraphRequestPath(requestPath), new JSONBody(body)));
+
+        // The endpoint should return a Response with the correct status and message.
+        final JsonObject expectedJson = Json
+                .createObjectBuilder()
+                .add("message", "Request has a malformed identifier!")
+                .build();
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST_400, response.status());
+        Assertions
+                .assertDoesNotThrow(() -> Assertions.assertEquals(expectedJson.toString(), response.body().asString()));
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(UpdateParagraphEndpoint.class).verify();
+    }
+}


### PR DESCRIPTION
This PR is separated from #4 to make code review more manageable.
Note that this PR by itself will likely contain references to objects that are not present in this PR. Please refer to PR #4, which contains all objects, in case you need to see how some objects interact. 

This PR contains endpoint objects, which define what procedures nbs_01 executes when a request for some operation is received.
closes #19 